### PR TITLE
Update to latest runtime schema to support RequestId header optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
         <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
         <jackson-databind-nullable-version>0.2.1</jackson-databind-nullable-version>
         <swagger-core-version>1.6.2</swagger-core-version>
-        <jackson-version>2.13.2.2</jackson-version>
-        <jackson-annotations-version>2.13.2</jackson-annotations-version>
+        <jackson-version>2.13.4.2</jackson-version>
+        <jackson-annotations-version>2.13.4</jackson-annotations-version>
         <javax-annotation-version>1.3.2</javax-annotation-version>
         <spring-boot-starter-webflux-version>2.5.12</spring-boot-starter-webflux-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/salesforce/einsteinbot/sdk/auth/JwtBearerOAuth.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/auth/JwtBearerOAuth.java
@@ -90,7 +90,8 @@ public class JwtBearerOAuth implements AuthMechanism {
     return clientResponse
         .bodyToMono(String.class)
         .flatMap(errorDetails -> Mono
-            .error(new OAuthResponseException(clientResponse.statusCode(), errorDetails)));
+            .error(new OAuthResponseException(clientResponse.statusCode(), errorDetails,
+                clientResponse.headers())));
   }
 
   @VisibleForTesting

--- a/src/main/java/com/salesforce/einsteinbot/sdk/client/model/BotHttpHeaders.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/client/model/BotHttpHeaders.java
@@ -25,9 +25,9 @@ import org.springframework.util.MultiValueMap;
 /**
  * BotHttpHeaders - Class to store/retrieve Http Headers used by Bot API Requests.
  *
- * As per RFC {@link https://www.rfc-editor.org/rfc/rfc7230#section-3.2} Http Header names
+ * As per RFC https://www.rfc-editor.org/rfc/rfc7230#section-3.2 Http Header names
  * are case insensitive. So we store them in uppercase. The get method would also convert
- * header name parameter to uppercase before lookup.
+ * header name parameter to lowercase before lookup.
  *
  * @author relango
  */
@@ -43,7 +43,7 @@ public class BotHttpHeaders {
     headerValues
         .entries()
         .stream()
-        .forEach(e -> this.headerValues.put(e.getKey().toUpperCase(), e.getValue()) );
+        .forEach(e -> this.headerValues.put(e.getKey().toLowerCase(), e.getValue()) );
   }
 
   private BotHttpHeaders(Set<Entry<String, List<String>>> entries) {
@@ -53,7 +53,7 @@ public class BotHttpHeaders {
   }
 
   private void addToHeader(Entry<String, List<String>> entry) {
-    headerValues.putAll(entry.getKey().toUpperCase(), entry.getValue());
+    headerValues.putAll(entry.getKey().toLowerCase(), entry.getValue());
   }
 
   public static Builder with() {
@@ -82,7 +82,7 @@ public class BotHttpHeaders {
 
   public Optional<String> getFirst(String headerName) {
     return Optional
-        .ofNullable(headerValues.get(headerName.toUpperCase()))
+        .ofNullable(headerValues.get(headerName.toLowerCase()))
         .flatMap(this::findFirstItem);
   }
 
@@ -95,7 +95,7 @@ public class BotHttpHeaders {
   }
 
   public Collection<String> get(String headerName) {
-    return headerValues.get(headerName.toUpperCase());
+    return headerValues.get(headerName.toLowerCase());
   }
 
   public Multimap<String, String> getHeaderValues() {
@@ -103,7 +103,7 @@ public class BotHttpHeaders {
   }
 
   public boolean containsHeader(String headerName){
-    return headerValues.containsKey(headerName.toUpperCase());
+    return headerValues.containsKey(headerName.toLowerCase());
   }
 
   @Override

--- a/src/main/java/com/salesforce/einsteinbot/sdk/client/model/BotRequest.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/client/model/BotRequest.java
@@ -47,12 +47,7 @@ public class BotRequest {
     this.requestEnvelopeInterceptor = requestEnvelopeInterceptor;
   }
 
-  @JsonIgnore
-  public String getOrCreateRequestId() {
-    return requestId.orElse(newRandomUUID());
-  }
-
-  public Optional getRequestId() {
+  public Optional<String> getRequestId() {
     return this.requestId;
   }
 
@@ -194,7 +189,7 @@ public class BotRequest {
 
     @Override
     public InitMessageOptionalFieldsBuilder<T> tz(String tz) {
-      this.tz = Optional.of(tz);
+      this.tz = Optional.ofNullable(tz);
       return this;
     }
 

--- a/src/main/java/com/salesforce/einsteinbot/sdk/client/model/BotSendMessageRequest.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/client/model/BotSendMessageRequest.java
@@ -87,9 +87,13 @@ public class BotSendMessageRequest extends BotRequest {
 
   @Override
   public String toString() {
-    return new StringJoiner(", ", BotSendMessageRequest.class.getSimpleName() + "{", "}")
+    return new StringJoiner(", ", BotSendMessageRequest.class.getSimpleName() + "[", "]")
         .add("variables=" + variables)
         .add("message=" + message)
+        .add("tz=" + tz)
+        .add("responseOptions=" + responseOptions)
+        .add("referrers=" + referrers)
+        .add("richContentCapabilities=" + richContentCapabilities)
         .add(super.toString())
         .toString();
   }

--- a/src/main/java/com/salesforce/einsteinbot/sdk/exception/ChatbotResponseException.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/exception/ChatbotResponseException.java
@@ -10,6 +10,7 @@ package com.salesforce.einsteinbot.sdk.exception;
 import com.salesforce.einsteinbot.sdk.model.Error;
 import java.util.StringJoiner;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse.Headers;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 /**
@@ -25,11 +26,14 @@ public class ChatbotResponseException extends WebClientException {
 
   private final int status;
   private final Error errorResponse;
+  private final Headers headers;
 
-  public ChatbotResponseException(HttpStatus status, Error errorResponse) {
+  public ChatbotResponseException(HttpStatus status, Error errorResponse,
+      Headers headers) {
     super(status.getReasonPhrase());
     this.status = status.value();
     this.errorResponse = errorResponse;
+    this.headers = headers;
   }
 
   public int getStatus() {
@@ -44,6 +48,7 @@ public class ChatbotResponseException extends WebClientException {
   public String toString() {
     return new StringJoiner(", ", ChatbotResponseException.class.getSimpleName() + "[", "]")
         .add("status = " + status)
+        .add("responseHeaders = " + headers)
         .add("errorResponse = " + errorResponse)
         .add("exception = " + super.toString())
         .toString();

--- a/src/main/java/com/salesforce/einsteinbot/sdk/exception/OAuthResponseException.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/exception/OAuthResponseException.java
@@ -9,6 +9,7 @@ package com.salesforce.einsteinbot.sdk.exception;
 
 import java.util.StringJoiner;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ClientResponse.Headers;
 import org.springframework.web.reactive.function.client.WebClientException;
 
 /**
@@ -21,10 +22,13 @@ public class OAuthResponseException extends WebClientException {
 
   private final HttpStatus status;
   private final String errorResponse;
+  private final Headers headers;
 
-  public OAuthResponseException(HttpStatus status, String errorResponse) {
+  public OAuthResponseException(HttpStatus status, String errorResponse,
+      Headers headers) {
     super(status.getReasonPhrase());
     this.status = status;
+    this.headers = headers;
     this.errorResponse = errorResponse;
   }
 
@@ -40,6 +44,7 @@ public class OAuthResponseException extends WebClientException {
   public String toString() {
     return new StringJoiner(", ", OAuthResponseException.class.getSimpleName() + "[", "]")
         .add("status = " + status)
+        .add("responseHeaders = " + headers)
         .add("errorResponse = " + errorResponse)
         .add("exception = " + super.toString())
         .toString();

--- a/src/main/java/com/salesforce/einsteinbot/sdk/util/UtilFunctions.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/util/UtilFunctions.java
@@ -135,7 +135,7 @@ public class UtilFunctions {
   }
 
   private static List<String> maskAuthorizationHeaderEntry(Map.Entry<String,List<String>> entry){
-    if (entry.getKey().toUpperCase().contains(HttpHeaders.AUTHORIZATION.toUpperCase())) {
+    if (entry.getKey().toLowerCase().contains(HttpHeaders.AUTHORIZATION.toLowerCase())) {
       return Lists.newArrayList(AUTHORIZATION_HEADER_MASKED);
     } else {
       return entry.getValue();

--- a/src/main/java/com/salesforce/einsteinbot/sdk/util/UtilFunctions.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/util/UtilFunctions.java
@@ -19,16 +19,20 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.google.common.collect.Lists;
 import com.salesforce.einsteinbot.sdk.handler.RFC3339DateFormat;
 import com.salesforce.einsteinbot.sdk.model.AnyVariable;
 import com.salesforce.einsteinbot.sdk.model.TextVariable;
 import java.text.DateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.TimeZone;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.http.HttpHeaders;
 
 /**
  * UtilFunctions - Contains static utility functions used in Application
@@ -39,6 +43,7 @@ public class UtilFunctions {
 
   private static final ObjectMapper mapper = getMapper();
   private static final DefaultPrettyPrinter prettyPrinter = new DefaultPrettyPrinter();
+  public static final String AUTHORIZATION_HEADER_MASKED = "MASKED";
 
 
   static {
@@ -118,5 +123,22 @@ public class UtilFunctions {
     dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
     return dateFormat;
+  }
+
+  public static Map<String, List<String>> maskAuthorizationHeader(HttpHeaders headers){
+    return headers.entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,
+            UtilFunctions::maskAuthorizationHeaderEntry));
+
+  }
+
+  private static List<String> maskAuthorizationHeaderEntry(Map.Entry<String,List<String>> entry){
+    if (entry.getKey().toUpperCase().contains(HttpHeaders.AUTHORIZATION.toUpperCase())) {
+      return Lists.newArrayList(AUTHORIZATION_HEADER_MASKED);
+    } else {
+      return entry.getValue();
+    }
   }
 }

--- a/src/main/java/com/salesforce/einsteinbot/sdk/util/WebClientUtil.java
+++ b/src/main/java/com/salesforce/einsteinbot/sdk/util/WebClientUtil.java
@@ -7,9 +7,18 @@
 
 package com.salesforce.einsteinbot.sdk.util;
 
+import static com.salesforce.einsteinbot.sdk.util.UtilFunctions.maskAuthorizationHeader;
+
+import com.google.common.collect.Lists;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.ClientRequest;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
@@ -27,7 +36,7 @@ public class WebClientUtil {
 
   public static Mono<ClientRequest> createLoggingRequestProcessor(ClientRequest clientRequest) {
     logger.info("Making {} Request to URI {} with Headers : {}", clientRequest.method(),
-        clientRequest.url(), clientRequest.headers());
+        clientRequest.url(), maskAuthorizationHeader(clientRequest.headers()));
     return Mono.just(clientRequest);
   }
 

--- a/src/main/resources/v5_0_0_api_specs.original.yml
+++ b/src/main/resources/v5_0_0_api_specs.original.yml
@@ -59,7 +59,7 @@ paths:
           name: "X-Request-ID"
           description: "Client supplied unique id to identify request for distributed tracing"
           example: "36a73651-a46d-4d16-9a8a-fd436ed62e1a"
-          required: true
+          required: false
           schema:
             type: "string"
       requestBody:
@@ -119,7 +119,7 @@ paths:
           name: "X-Request-ID"
           description: "Client supplied unique id to identify request for distributed tracing"
           example: "36a73651-a46d-4d16-9a8a-fd436ed62e1a"
-          required: true
+          required: false
           schema:
             type: "string"
         - in: "header"
@@ -192,7 +192,7 @@ paths:
           name: "X-Request-ID"
           description: "Client supplied unique id to identify request for distributed tracing"
           example: "36a73651-a46d-4d16-9a8a-fd436ed62e1a"
-          required: true
+          required: false
           schema:
             type: "string"
         - in: "header"

--- a/src/main/resources/v5_0_0_api_specs.yml
+++ b/src/main/resources/v5_0_0_api_specs.yml
@@ -59,7 +59,7 @@ paths:
           name: "X-Request-ID"
           description: "Client supplied unique id to identify request for distributed tracing"
           example: "36a73651-a46d-4d16-9a8a-fd436ed62e1a"
-          required: true
+          required: false
           schema:
             type: "string"
       requestBody:
@@ -119,7 +119,7 @@ paths:
           name: "X-Request-ID"
           description: "Client supplied unique id to identify request for distributed tracing"
           example: "36a73651-a46d-4d16-9a8a-fd436ed62e1a"
-          required: true
+          required: false
           schema:
             type: "string"
         - in: "header"
@@ -192,7 +192,7 @@ paths:
           name: "X-Request-ID"
           description: "Client supplied unique id to identify request for distributed tracing"
           example: "36a73651-a46d-4d16-9a8a-fd436ed62e1a"
-          required: true
+          required: false
           schema:
             type: "string"
         - in: "header"

--- a/src/test/java/com/salesforce/einsteinbot/sdk/client/BasicChatbotClientTest.java
+++ b/src/test/java/com/salesforce/einsteinbot/sdk/client/BasicChatbotClientTest.java
@@ -149,8 +149,8 @@ public class BasicChatbotClientTest {
 
     InitMessageEnvelope initMessageEnvelope = buildInitMessageEnvelope();
 
-    when(mockBotApi.establishChatSessionWithHttpInfo(eq(botId), eq(orgId), eq(requestId),
-        eq(initMessageEnvelope)))
+    when(mockBotApi.establishChatSessionWithHttpInfo(eq(botId), eq(orgId),
+        eq(initMessageEnvelope),  eq(requestId)))
         .thenReturn(createMonoApiResponse(responseEntity));
 
     BotResponse response = client.startChatSession(config, new ExternalSessionId(externalSessionId),
@@ -183,8 +183,8 @@ public class BasicChatbotClientTest {
 
     ChatMessageEnvelope chatMessageEnvelope = buildChatMessageEnvelope();
 
-    when(mockBotApi.continueChatSessionWithHttpInfo(eq(sessionId), eq(orgId), eq(requestId),
-        eq(chatMessageEnvelope), eq(runtimeCRC)))
+    when(mockBotApi.continueChatSessionWithHttpInfo(eq(sessionId), eq(orgId),
+        eq(chatMessageEnvelope), eq(requestId), eq(runtimeCRC)))
         .thenReturn(createMonoApiResponse(responseEntity));
 
     BotResponse response = client.sendMessage(config, new RuntimeSessionId(sessionId),
@@ -201,8 +201,8 @@ public class BasicChatbotClientTest {
 
     ChatMessageEnvelope chatMessageEnvelope = buildChatMessageEnvelope();
 
-    when(mockBotApi.continueChatSessionWithHttpInfo(eq(sessionId), eq(orgId), eq(requestId),
-        eq(chatMessageEnvelope), eq(runtimeCRC)))
+    when(mockBotApi.continueChatSessionWithHttpInfo(eq(sessionId), eq(orgId),
+        eq(chatMessageEnvelope),  eq(requestId), eq(runtimeCRC)))
         .thenReturn(createMonoApiResponse(responseEntity));
 
     BotSendMessageRequest botSendMessageReq = BotRequest
@@ -309,8 +309,8 @@ public class BasicChatbotClientTest {
   }
 
   private void verifyResponseHeaders(BotHttpHeaders actualHttpHeaders) {
-    assertEquals(Optional.empty(), actualHttpHeaders.getRuntimeCRCHeader());
-    assertEquals(Optional.ofNullable(responseRequestId), actualHttpHeaders.getRequestIdHeader());
+    assertTrue(actualHttpHeaders.getRuntimeCRCHeaderAsCSV().isEmpty());
+    assertEquals(responseRequestId, actualHttpHeaders.getRequestIdHeaderAsCSV());
   }
 
   @Test

--- a/src/test/java/com/salesforce/einsteinbot/sdk/client/ClientApiWireMockTest.java
+++ b/src/test/java/com/salesforce/einsteinbot/sdk/client/ClientApiWireMockTest.java
@@ -229,8 +229,8 @@ public class ClientApiWireMockTest {
     assertEquals(botResponse.getHttpStatusCode(), HttpStatus.OK.value());
     BotHttpHeaders actualHttpHeaders = botResponse.getHttpHeaders();
 
-    assertEquals(Optional.empty(), actualHttpHeaders.getRuntimeCRCHeader());
-    assertEquals(Optional.ofNullable(responseRequestId), actualHttpHeaders.getRequestIdHeader());
+    assertTrue(actualHttpHeaders.getRuntimeCRCHeaderAsCSV().isEmpty());
+    assertEquals(responseRequestId, String.join(", ", actualHttpHeaders.getRequestIdHeaderAsCSV()));
     verifyResponseEnvelope(responseBodyFile, botResponse.getResponseEnvelope());
 
     ResponseEnvelope responseEnvelope = botResponse.getResponseEnvelope();

--- a/src/test/java/com/salesforce/einsteinbot/sdk/client/model/BotHttpHeadersTest.java
+++ b/src/test/java/com/salesforce/einsteinbot/sdk/client/model/BotHttpHeadersTest.java
@@ -37,17 +37,21 @@ public class BotHttpHeadersTest {
         .header(customHeaderName, customHeaderValue2)
         .build();
 
-    //RuntimeCRC is not provided, so it should be present
-    assertFalse(botHeader.getRuntimeCRCHeader().isPresent());
+    //RuntimeCRC is not provided, so it should not be present
+    assertTrue(botHeader.getRuntimeCRCHeaderAsCSV().isEmpty());
 
-    assertTrue(botHeader.getRequestIdHeader().isPresent());
-    assertEquals(requestId, botHeader.getRequestIdHeader().get());
+    assertFalse(botHeader.getRequestIdHeaderAsCSV().isEmpty());
+    assertEquals(requestId, String.join(",", botHeader.getRequestIdHeaderAsCSV()));
 
     Map<String, Collection<String>> allHeaders = botHeader.getAll();
-    assertTrue(allHeaders.containsKey(customHeaderName));
+    assertTrue(botHeader.containsHeader(customHeaderName));
 
     //Verify we can store multiple values for same header.
-    assertTrue(allHeaders.get(customHeaderName)
+    assertTrue(botHeader.get(customHeaderName)
+        .containsAll(Arrays.asList(customHeaderValue1, customHeaderValue2)));
+
+    //Verify reading header value in case insensitive way
+    assertTrue(botHeader.get(customHeaderName.toLowerCase())
         .containsAll(Arrays.asList(customHeaderValue1, customHeaderValue2)));
   }
 }

--- a/src/test/java/com/salesforce/einsteinbot/sdk/client/model/BotRequestTest.java
+++ b/src/test/java/com/salesforce/einsteinbot/sdk/client/model/BotRequestTest.java
@@ -83,7 +83,7 @@ public class BotRequestTest {
 
     assertTrue(botRequest instanceof BotEndSessionRequest);
     assertEquals(endSessionReason, ((BotEndSessionRequest) botRequest).getEndSessionReason());
-    assertNotNull(botRequest.getOrCreateRequestId());
+    assertFalse(botRequest.getRequestId().isPresent());
     assertFalse(botRequest.getRuntimeCRC().isPresent());
   }
 }

--- a/src/test/java/com/salesforce/einsteinbot/sdk/client/model/BotResponseTest.java
+++ b/src/test/java/com/salesforce/einsteinbot/sdk/client/model/BotResponseTest.java
@@ -15,7 +15,7 @@ import com.salesforce.einsteinbot.sdk.client.util.ResponseFactory;
 import com.salesforce.einsteinbot.sdk.model.ChatMessageResponseEnvelope;
 import com.salesforce.einsteinbot.sdk.model.ResponseEnvelope;
 import com.salesforce.einsteinbot.sdk.util.TestUtils;
-import java.util.Optional;
+import java.util.Collection;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -53,9 +53,8 @@ public class BotResponseTest {
     assertEquals(httpStatusCode, botResponse.getHttpStatusCode());
     assertEquals(botHttpHeaders, botResponse.getHttpHeaders());
 
-    Optional<String> actualRequestId = botResponse.getHttpHeaders().getRequestIdHeader();
-    assertTrue(actualRequestId.isPresent());
-    assertEquals(requestId, actualRequestId.get());
+    String actualRequestId = botResponse.getHttpHeaders().getRequestIdHeaderAsCSV();
+    assertEquals(requestId, actualRequestId);
   }
 
   @Test

--- a/src/test/java/com/salesforce/einsteinbot/sdk/util/UtilFunctionsTest.java
+++ b/src/test/java/com/salesforce/einsteinbot/sdk/util/UtilFunctionsTest.java
@@ -10,6 +10,7 @@ package com.salesforce.einsteinbot.sdk.util;
 import static com.salesforce.einsteinbot.sdk.util.Constants.CONTEXT_VARIABLE_NAME_INTEGRATION_NAME;
 import static com.salesforce.einsteinbot.sdk.util.Constants.CONTEXT_VARIABLE_NAME_INTEGRATION_TYPE;
 import static com.salesforce.einsteinbot.sdk.util.Constants.CONTEXT_VARIABLE_VALUE_API;
+import static com.salesforce.einsteinbot.sdk.util.UtilFunctions.AUTHORIZATION_HEADER_MASKED;
 import static com.salesforce.einsteinbot.sdk.util.UtilFunctions.addIntegrationTypeAndNameToContextVariables;
 import static com.salesforce.einsteinbot.sdk.util.UtilFunctions.createTextVariable;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,14 +18,18 @@ import static org.hamcrest.Matchers.contains;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.Lists;
 import com.salesforce.einsteinbot.sdk.model.AnyVariable;
 import com.salesforce.einsteinbot.sdk.model.TextVariable;
 import com.salesforce.einsteinbot.sdk.model.TextVariable.TypeEnum;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
 
 /**
  * UtilFunctionsTest - Unit Tests for methods in UtilFunctions
@@ -79,5 +84,20 @@ public class UtilFunctionsTest {
         currentContextVariables, Optional.empty());
 
     assertTrue(newContextVariables.isEmpty());
+  }
+
+  @Test
+  public void testMaskAuthorizationHeader(){
+    HttpHeaders headers = new HttpHeaders();
+    String requestId1 = "request-id1";
+    String requestId2 = "request-id2";
+    headers.add("X-Request-Id", requestId1);
+    headers.add("X-Request-Id", requestId2);
+    headers.add(HttpHeaders.AUTHORIZATION, "auth");
+    headers.add("X-SCRT-AUTHORIZATION", "scrt-auth");
+    Map<String, List<String>> masked = UtilFunctions.maskAuthorizationHeader(headers);
+    assertEquals(Lists.newArrayList(AUTHORIZATION_HEADER_MASKED),masked.get(HttpHeaders.AUTHORIZATION));
+    assertEquals(Lists.newArrayList(AUTHORIZATION_HEADER_MASKED), masked.get("X-SCRT-AUTHORIZATION"));
+    assertEquals(Lists.newArrayList(requestId1, requestId2), masked.get("X-Request-Id"));
   }
 }


### PR DESCRIPTION
- Update to latest runtime schema to support RequestId header optional
- GDPR complaince changes to not log request payload and mask authentication tokens 
- Fixed security vulnerabilities in 3PP libraries
- Support for case insensitive Bot Response Http headers